### PR TITLE
Add lexical-binding cookie

### DIFF
--- a/oblique.el
+++ b/oblique.el
@@ -1,4 +1,4 @@
-;;; oblique.el --- Provide an oblique strategy
+;;; oblique.el --- Provide an oblique strategy  -*- lexical-binding: t; -*-
 
 ;; Copyright FoAM 2011
 ;;


### PR DESCRIPTION
This addressed the warning emitted when byte-compiling the file

```
⛔ Warning (files): Missing ‘lexical-binding’ cookie in "~/.emacs.d/elpa/oblique/oblique.el".
You can add one with ‘M-x elisp-enable-lexical-binding RET’.
See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
for more information.
```